### PR TITLE
optimize

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -33,7 +33,7 @@ compile 'com.aliyun.dpa:oss-android-sdk:+'
 $ git clone https://github.com/aliyun/aliyun-oss-android-sdk.git
 
 # 进入目录
-$ cd aliyun-oss-android-sdk/oss-android-sdk/
+$ cd aliyun-oss-android-sdk/
 
 # 执行打包脚本，要求jdk 1.7
 $ ./gradlew releaseJar

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can run the gradle command for packaging after cloning the project source co
 $ git clone https://github.com/aliyun/aliyun-oss-android-sdk.git
 
 # Enter the directory
-$ cd aliyun-oss-android-sdk/oss-android-sdk/
+$ cd aliyun-oss-android-sdk/
 
 # Run the packaging script. JDK 1.7 is required
 $ ./gradlew releaseJar

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,14 @@ Github地址：https://github.com/aliyun/aliyun-oss-android-sdk
 
 更新日志:
 
+2018/09/11
+- release 2.9.1
+1. fix bug about 409 error for sequentially uploading object.
+2. fix bug about losing port of endpoint.
+3. optimize logic about time synchronization.
+4. should not use endpoint with format of https://ipadress.
+5. support carry custom headers for getObject api.
+
 2018/08/23
 - release 2.9.0
 1.	add http2 support

--- a/oss-android-sdk/build.gradle
+++ b/oss-android-sdk/build.gradle
@@ -14,8 +14,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 25
-        versionCode 38
-        versionName "2.9.0"
+        versionCode 39
+        versionName "2.9.1"
     }
 
     buildTypes {

--- a/oss-android-sdk/src/androidTest/java/com/alibaba/sdk/android/OSSUtilsTest.java
+++ b/oss-android-sdk/src/androidTest/java/com/alibaba/sdk/android/OSSUtilsTest.java
@@ -187,7 +187,7 @@ public class OSSUtilsTest extends AndroidTestCase {
         }
     }
 
-    public void testValidateIpV6(){
+    public void testIsValidateIPWithRightIPV6(){
         String ipv6address = "2401:b180::dc";
         try{
             Boolean isValidateIp = OSSUtils.isValidateIP(ipv6address);
@@ -197,13 +197,43 @@ public class OSSUtilsTest extends AndroidTestCase {
         }
     }
 
-    public void testErrorIpV6(){
+    public void testIsValidateIPWithWrongIPV6(){
         String ipv6address = "2401:b180:error:dc";
         try{
             Boolean isValidateIp = OSSUtils.isValidateIP(ipv6address);
             assertFalse(isValidateIp);
         }catch (Exception e){
-            assertTrue(true);
+            assertFalse(true);
+        }
+    }
+
+    public void testIsValidateIPWithRightIPV4(){
+        String ipv6address = "192.168.0.1";
+        try{
+            Boolean isValidateIp = OSSUtils.isValidateIP(ipv6address);
+            assertTrue(isValidateIp);
+        }catch (Exception e){
+            assertTrue(false);
+        }
+    }
+
+    public void testIsValidateIPWithWrongIPV4(){
+        String ipv6address = "256.168.0.1";
+        try{
+            Boolean isValidateIp = OSSUtils.isValidateIP(ipv6address);
+            assertFalse(isValidateIp);
+        }catch (Exception e){
+            assertFalse(true);
+        }
+    }
+
+    public void testIsValidateIPWithHost(){
+        String ipv6address = "www.aliyun.com";
+        try{
+            Boolean isValidateIp = OSSUtils.isValidateIP(ipv6address);
+            assertFalse(isValidateIp);
+        }catch (Exception e){
+            assertFalse(true);
         }
     }
 

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/OSSImpl.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/OSSImpl.java
@@ -12,6 +12,7 @@ import android.content.Context;
 import com.alibaba.sdk.android.oss.callback.OSSCompletedCallback;
 import com.alibaba.sdk.android.oss.common.OSSLogToFileUtils;
 import com.alibaba.sdk.android.oss.common.auth.OSSCredentialProvider;
+import com.alibaba.sdk.android.oss.common.utils.OSSUtils;
 import com.alibaba.sdk.android.oss.internal.ExtensionRequestOperation;
 import com.alibaba.sdk.android.oss.internal.InternalRequestOperation;
 import com.alibaba.sdk.android.oss.internal.OSSAsyncTask;
@@ -110,6 +111,18 @@ class OSSImpl implements OSS {
         if (credentialProvider == null) {
             throw new IllegalArgumentException("CredentialProvider can't be null.");
         }
+
+        Boolean hostIsIP = false;
+        try {
+            hostIsIP = OSSUtils.isValidateIP(this.endpointURI.getHost());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        if (this.endpointURI.getScheme().equals("https") && hostIsIP) {
+            throw new IllegalArgumentException("endpoint should not be format with https://ip.");
+        }
+
         this.credentialProvider = credentialProvider;
         this.conf = (conf == null ? ClientConfiguration.getDefaultConf() : conf);
 

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/ServiceException.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/ServiceException.java
@@ -61,6 +61,31 @@ public class ServiceException extends Exception {
      */
     private String rawMessage;
 
+    /**
+     * part number
+     */
+    private String partNumber;
+
+    /**
+     * part etag
+     */
+    private String partEtag;
+
+    public String getPartNumber() {
+        return partNumber;
+    }
+
+    public void setPartNumber(String partNumber) {
+        this.partNumber = partNumber;
+    }
+
+    public String getPartEtag() {
+        return partEtag;
+    }
+
+    public void setPartEtag(String partEtag) {
+        this.partEtag = partEtag;
+    }
 
     /**
      * The constructor with status code, message, error code , request Id and host Id

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/common/OSSConstants.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/common/OSSConstants.java
@@ -5,7 +5,7 @@ package com.alibaba.sdk.android.oss.common;
  */
 public final class OSSConstants {
 
-    public static final String SDK_VERSION = "2.9.0";
+    public static final String SDK_VERSION = "2.9.1";
     public static final String DEFAULT_OSS_ENDPOINT = "http://oss-cn-hangzhou.aliyuncs.com";
 
     public static final String DEFAULT_CHARSET_NAME = "utf-8";

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/common/utils/OSSUtils.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/common/utils/OSSUtils.java
@@ -783,7 +783,7 @@ public class OSSUtils {
             return false;
         }
 
-        if (ia.getHostName().equals(ia.getHostAddress())) {
+        if (host.equals(ia.getHostAddress())) {
             return true;
         }
 

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/common/utils/OSSUtils.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/common/utils/OSSUtils.java
@@ -775,21 +775,18 @@ public class OSSUtils {
         if (host == null) {
             throw new Exception("host is null");
         }
-        InetAddress inetAddress = InetAddress.getByName(host);
-        if (host.equalsIgnoreCase(inetAddress.getHostAddress())){
-            byte[] address = inetAddress.getAddress();
-            if (address == null){
-                throw new Exception("get ip address bytes failed");
-            }
-            if(address.length == 4 && inetAddress instanceof Inet4Address){
-                OSSLog.logDebug("ipAddr is ipv4");
-                return true;
-            }
-            if(address.length == 16 && inetAddress instanceof Inet6Address){
-                OSSLog.logDebug("ipAddr is ip6");
-                return true;
-            }
+
+        InetAddress ia;
+        try {
+            ia = InetAddress.getByName(host);
+        } catch (UnknownHostException e) {
+            return false;
         }
+
+        if (ia.getHostName().equals(ia.getHostAddress())) {
+            return true;
+        }
+
         return false;
     }
 

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/InternalRequestOperation.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/InternalRequestOperation.java
@@ -454,6 +454,12 @@ public class InternalRequestOperation {
 
         canonicalizeRequestMessage(requestMessage, request);
 
+        if (request.getRequestHeaders() != null) {
+            for (Map.Entry<String, String> entry : request.getRequestHeaders().entrySet()) {
+                requestMessage.getHeaders().put(entry.getKey(), entry.getValue());
+            }
+        }
+
         ExecutionContext<GetObjectRequest, GetObjectResult> executionContext = new ExecutionContext(getInnerClient(), request, applicationContext);
         if (completedCallback != null) {
             executionContext.setCompletedCallback(completedCallback);

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/RequestMessage.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/RequestMessage.java
@@ -212,8 +212,6 @@ public class RequestMessage extends HttpMessage {
     public String buildCanonicalURL() throws Exception{
         OSSUtils.assertTrue(endpoint != null, "Endpoint haven't been set!");
 
-        String baseURL;
-
         String scheme = endpoint.getScheme();
         String originHost = endpoint.getHost();
         String portString = null;
@@ -233,36 +231,65 @@ public class RequestMessage extends HttpMessage {
         OSSLog.logDebug(" originHost : " + originHost);
         OSSLog.logDebug(" port : " + portString);
 
+        String baseURL = endpoint.toString();
+
+        if (!TextUtils.isEmpty(bucketName)) {
+            if (OSSUtils.isValidateIP(originHost)) {
+                // ip address
+                baseURL = endpoint.toString() + "/" + bucketName;
+            } else if (OSSUtils.isOssOriginHost(originHost)) {
+                // official endpoint
+                originHost = bucketName + "." + originHost;
+                String urlHost = null;
+                if (isHttpDnsEnable()) {
+                    urlHost = HttpdnsMini.getInstance().getIpByHostAsync(originHost);
+                } else {
+                    OSSLog.logDebug("[buildCannonicalURL], disable httpdns");
+                }
+                addHeader(OSSHeaders.HOST, originHost);
+
+                if (!TextUtils.isEmpty(urlHost)) {
+                    baseURL = scheme + "://" + urlHost;
+                } else {
+                    baseURL = scheme + "://" + originHost;
+                }
+            } else {
+                // cname时不做任何处理
+                baseURL = endpoint.toString();
+            }
+        } else {
+            baseURL = endpoint.toString();
+        }
 
         /*
          * edited by wangzheng.
          * 重新整理url build 逻辑。如果是标准阿里云的域名。通过bucket拼装获取实际访问url。
          * 否则，直接用用户传入的自定义域名或者ip链接object 进行访问。
          */
-        if (OSSUtils.isOssOriginHost(originHost) && !TextUtils.isEmpty(bucketName)){
-            originHost = bucketName + "." + originHost;
-            String urlHost = null;
-            if (isHttpDnsEnable()) {
-                urlHost = HttpdnsMini.getInstance().getIpByHostAsync(originHost);
-            } else {
-                OSSLog.logDebug("[buildCannonicalURL], disable httpdns");
-            }
-            // The urlHost is null when the asynchronous DNS resolution API never returns IP.
-            if (urlHost == null) {
-                urlHost = originHost;
-            }
-            String headerHost = originHost;
+//        if (OSSUtils.isOssOriginHost(originHost) && !TextUtils.isEmpty(bucketName)){
+//            originHost = bucketName + "." + originHost;
+//            String urlHost = null;
+//            if (isHttpDnsEnable()) {
+//                urlHost = HttpdnsMini.getInstance().getIpByHostAsync(originHost);
+//            } else {
+//                OSSLog.logDebug("[buildCannonicalURL], disable httpdns");
+//            }
+//            // The urlHost is null when the asynchronous DNS resolution API never returns IP.
+//            if (urlHost == null) {
+//                urlHost = originHost;
+//            }
+//            String headerHost = originHost;
 
             // isCname and isOssOriginHost are mutually exclusive, so code below will never be executed!
 //            if (OSSUtils.isCname(originHost) && this.isInCustomCnameExcludeList() && !TextUtils.isEmpty(bucketName)) {
 //                headerHost = bucketName + "." + originHost;
 //            }
-            addHeader(OSSHeaders.HOST, originHost);
-            baseURL = scheme + "://" + urlHost;
-
-        } else {
-            baseURL = scheme + "://" + originHost;
-        }
+//            addHeader(OSSHeaders.HOST, originHost);
+//            baseURL = scheme + "://" + urlHost;
+//
+//        } else {
+//            baseURL = scheme + "://" + originHost;
+//        }
 
 //        if (OSSUtils.isValidateIP(originHost)) {
 //            baseURL = scheme + "://" + originHost + "/" + bucketName;
@@ -291,11 +318,6 @@ public class RequestMessage extends HttpMessage {
 //            addHeader(OSSHeaders.HOST, headerHost);
 //            baseURL = scheme + "://" + urlHost;
 //        }
-
-
-        if (!TextUtils.isEmpty(portString)) {
-            baseURL += ":" + portString;
-        }
 
         if (!TextUtils.isEmpty(objectKey)) {
             baseURL += "/" + HttpUtil.urlEncode(objectKey, OSSConstants.DEFAULT_CHARSET_NAME);

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/RequestMessage.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/RequestMessage.java
@@ -252,10 +252,12 @@ public class RequestMessage extends HttpMessage {
                 urlHost = originHost;
             }
             String headerHost = originHost;
-            if (OSSUtils.isCname(originHost) && this.isInCustomCnameExcludeList() && !TextUtils.isEmpty(bucketName)) {
-                headerHost = bucketName + "." + originHost;
-            }
-            addHeader(OSSHeaders.HOST, headerHost);
+
+            // isCname and isOssOriginHost are mutually exclusive, so code below will never be executed!
+//            if (OSSUtils.isCname(originHost) && this.isInCustomCnameExcludeList() && !TextUtils.isEmpty(bucketName)) {
+//                headerHost = bucketName + "." + originHost;
+//            }
+            addHeader(OSSHeaders.HOST, originHost);
             baseURL = scheme + "://" + urlHost;
 
         } else {

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/RequestMessage.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/RequestMessage.java
@@ -216,6 +216,13 @@ public class RequestMessage extends HttpMessage {
 
         String scheme = endpoint.getScheme();
         String originHost = endpoint.getHost();
+        String portString = null;
+
+        int port = endpoint.getPort();
+        if (port != -1) {
+            portString = String.valueOf(port);
+        }
+
         if (TextUtils.isEmpty(originHost)){
             String url = endpoint.toString();
             OSSLog.logDebug("endpoint url : " + url);
@@ -224,6 +231,8 @@ public class RequestMessage extends HttpMessage {
 
         OSSLog.logDebug(" scheme : " + scheme);
         OSSLog.logDebug(" originHost : " + originHost);
+        OSSLog.logDebug(" port : " + portString);
+
 
         /*
          * edited by wangzheng.
@@ -249,7 +258,7 @@ public class RequestMessage extends HttpMessage {
             addHeader(OSSHeaders.HOST, headerHost);
             baseURL = scheme + "://" + urlHost;
 
-        }else{
+        } else {
             baseURL = scheme + "://" + originHost;
         }
 
@@ -280,6 +289,10 @@ public class RequestMessage extends HttpMessage {
 //            addHeader(OSSHeaders.HOST, headerHost);
 //            baseURL = scheme + "://" + urlHost;
 //        }
+
+        if (portString != null) {
+            baseURL += ":" + portString;
+        }
 
         if (objectKey != null) {
             baseURL += "/" + HttpUtil.urlEncode(objectKey, OSSConstants.DEFAULT_CHARSET_NAME);

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/ResponseParsers.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/ResponseParsers.java
@@ -645,6 +645,8 @@ public final class ResponseParsers {
         String code = null;
         String message = null;
         String hostId = null;
+        String partNumber = null;
+        String partEtag = null;
         String errorMessage = null;
         if (!isHeadRequest) {
             try {
@@ -665,6 +667,10 @@ public final class ResponseParsers {
                                 requestId = parser.nextText();
                             } else if ("HostId".equals(parser.getName())) {
                                 hostId = parser.nextText();
+                            } else if ("PartNumber".equals(parser.getName())) {
+                                partNumber = parser.nextText();
+                            } else if ("PartEtag".equals(parser.getName())) {
+                                partEtag = parser.nextText();
                             }
                             break;
                     }
@@ -681,7 +687,17 @@ public final class ResponseParsers {
             }
         }
 
-        return new ServiceException(statusCode, message, code, requestId, hostId, errorMessage);
+        ServiceException serviceException = new ServiceException(statusCode, message, code, requestId, hostId, errorMessage);
+        if (partEtag != null) {
+            serviceException.setPartEtag(partEtag);
+        }
+
+        if (partNumber != null) {
+            serviceException.setPartNumber(partNumber);
+        }
+
+
+        return serviceException;
     }
 
     public static final class PutObjectResponseParser extends AbstractResponseParser<PutObjectResult> {

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/SequenceUploadTask.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/SequenceUploadTask.java
@@ -302,7 +302,7 @@ public class SequenceUploadTask extends BaseMultipartUploadTask<ResumableUploadR
             // it is not necessary to throw 409 PartAlreadyExist exception out
             if (e.getStatusCode() != 409) {
                 processException(e);
-
+            } else {
                 PartETag partETag = new PartETag(uploadPartRequest.getPartNumber(), e.getPartEtag());
                 partETag.setPartSize(uploadPartRequest.getPartContent().length);
                 if (mCheckCRC64) {

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/SequenceUploadTask.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/internal/SequenceUploadTask.java
@@ -8,6 +8,7 @@ import com.alibaba.sdk.android.oss.TaskCancelException;
 import com.alibaba.sdk.android.oss.callback.OSSCompletedCallback;
 import com.alibaba.sdk.android.oss.common.OSSLog;
 import com.alibaba.sdk.android.oss.common.utils.BinaryUtil;
+import com.alibaba.sdk.android.oss.common.utils.CRC64;
 import com.alibaba.sdk.android.oss.common.utils.OSSSharedPreferences;
 import com.alibaba.sdk.android.oss.common.utils.OSSUtils;
 import com.alibaba.sdk.android.oss.model.AbortMultipartUploadRequest;
@@ -26,12 +27,14 @@ import com.alibaba.sdk.android.oss.network.ExecutionContext;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.RandomAccessFile;
@@ -40,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.zip.CheckedInputStream;
 
 /**
  * Created by jingdan on 2017/10/30.
@@ -252,6 +256,7 @@ public class SequenceUploadTask extends BaseMultipartUploadTask<ResumableUploadR
     public void uploadPart(int readIndex, int byteCount, int partNumber) {
 
         RandomAccessFile raf = null;
+        UploadPartRequest uploadPartRequest = null;
         try {
 
             if (mContext.getCancellationHandler().isCancelled()) {
@@ -263,18 +268,19 @@ public class SequenceUploadTask extends BaseMultipartUploadTask<ResumableUploadR
             preUploadPart(readIndex, byteCount, partNumber);
 
             raf = new RandomAccessFile(mUploadFile, "r");
-            UploadPartRequest uploadPart = new UploadPartRequest(
+
+            uploadPartRequest = new UploadPartRequest(
                     mRequest.getBucketName(), mRequest.getObjectKey(), mUploadId, readIndex + 1);
             long skip = readIndex * mRequest.getPartSize();
             byte[] partContent = new byte[byteCount];
             raf.seek(skip);
             raf.readFully(partContent, 0, byteCount);
-            uploadPart.setPartContent(partContent);
-            uploadPart.setMd5Digest(BinaryUtil.calculateBase64Md5(partContent));
-            uploadPart.setCRC64(mRequest.getCRC64());
-            UploadPartResult uploadPartResult = mApiOperation.syncUploadPart(uploadPart);
+            uploadPartRequest.setPartContent(partContent);
+            uploadPartRequest.setMd5Digest(BinaryUtil.calculateBase64Md5(partContent));
+            uploadPartRequest.setCRC64(mRequest.getCRC64());
+            UploadPartResult uploadPartResult = mApiOperation.syncUploadPart(uploadPartRequest);
             //check isComplete，throw exception when error occur
-            PartETag partETag = new PartETag(uploadPart.getPartNumber(), uploadPartResult.getETag());
+            PartETag partETag = new PartETag(uploadPartRequest.getPartNumber(), uploadPartResult.getETag());
             partETag.setPartSize(byteCount);
             if (mCheckCRC64) {
                 partETag.setCRC64(uploadPartResult.getClientCRC());
@@ -296,6 +302,19 @@ public class SequenceUploadTask extends BaseMultipartUploadTask<ResumableUploadR
             // it is not necessary to throw 409 PartAlreadyExist exception out
             if (e.getStatusCode() != 409) {
                 processException(e);
+
+                PartETag partETag = new PartETag(uploadPartRequest.getPartNumber(), e.getPartEtag());
+                partETag.setPartSize(uploadPartRequest.getPartContent().length);
+                if (mCheckCRC64) {
+                    byte[] partContent = uploadPartRequest.getPartContent();
+                    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(partContent);
+                    CheckedInputStream checkedInputStream = new CheckedInputStream(byteArrayInputStream, new CRC64());
+
+                    partETag.setCRC64(checkedInputStream.getChecksum().getValue());
+                }
+
+                mPartETags.add(partETag);
+                mUploadedLength += byteCount;
             }
         } catch (Exception e) {
             processException(e);

--- a/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/model/GetObjectRequest.java
+++ b/oss-android-sdk/src/main/java/com/alibaba/sdk/android/oss/model/GetObjectRequest.java
@@ -2,6 +2,8 @@ package com.alibaba.sdk.android.oss.model;
 
 import com.alibaba.sdk.android.oss.callback.OSSProgressCallback;
 
+import java.util.Map;
+
 /**
  * Created by zhouzhuo on 11/23/15.
  */
@@ -20,6 +22,17 @@ public class GetObjectRequest extends OSSRequest {
 
     // progress callback run with not ui thread
     private OSSProgressCallback progressListener;
+
+    // request headers
+    private Map<String, String> requestHeaders;
+
+    public Map<String, String> getRequestHeaders() {
+        return requestHeaders;
+    }
+
+    public void setRequestHeaders(Map<String, String> requestHeaders) {
+        this.requestHeaders = requestHeaders;
+    }
 
     /**
      * Creates the new request to get the specified object

--- a/project.properties
+++ b/project.properties
@@ -2,7 +2,7 @@
 project.name=aliyun-oss-sdk-android
 project.groupId=com.aliyun.dpa
 project.artifactId=oss-android-sdk
-project.version=2.9.0
+project.version=2.9.1
 project.packaging=aar
 project.siteUrl=https://github.com/aliyun/aliyun-oss-android-sdk
 project.gitUrl=https://github.com/aliyun/aliyun-oss-android-sdk.git


### PR DESCRIPTION
1.OSSClient初始化时传入的endpoint不允许https://ip 形式；
2.GetObject操作支持用户传入自定义的header；
3.优化时间同步逻辑；